### PR TITLE
feat: removed jQuery

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -460,7 +460,7 @@ export default class DomPredictionHelper {
         .replace(/[\+\~\>]\s*,/g, ",")
         .replace(/[\+\~]\s*>/g, ">")
         .replace(/\s*(,\s*)+/g, " , ")
-        .replace(/#(\d[\w\-]+)/g, '[id="$1"]');
+        .replace(/#(\d([\w\-]|\\:|\\.)+)/g, '[id="$1"]');
     }
     return cleaned_css;
   }

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-import { diff_match_patch } from 'diff_match_patch';
+import { diff_match_patch } from "diff_match_patch";
 
 export default class DomPredictionHelper {
   recursiveNodes(e) {
@@ -8,7 +8,7 @@ export default class DomPredictionHelper {
     } else {
       n = new Array();
     }
-
+    
     if (e.host && e.host.shadowRoot) return n;
     n.push(e);
     return n;
@@ -18,24 +18,24 @@ export default class DomPredictionHelper {
     if (name) {
       try {
         return name
-          .replace(/\bselectorgadget_\w+\b/g, '')
-          .replace(/\\/g, '\\\\')
+          .replace(/\bselectorgadget_\w+\b/g, "")
+          .replace(/\\/g, "\\\\")
           .replace(
             /[\#\;\&\,\.\+\*\~\'\:\"\!\^\$\[\]\(\)\=\>\|\/]/g,
             e => `\\${e}`
           )
-          .replace(/\s+/, '');
+          .replace(/\s+/, "");
       } catch (e) {
         if (window.console) {
-          console.log('---');
-          console.log('exception in escapeCssNames');
+          console.log("---");
+          console.log("exception in escapeCssNames");
           console.log(name);
-          console.log('---');
+          console.log("---");
         }
-        return '';
+        return "";
       }
     } else {
-      return '';
+      return "";
     }
   }
 
@@ -56,7 +56,7 @@ export default class DomPredictionHelper {
     filtered_nodes = [];
     for (_i = 0, _len = nodes.length; _i < _len; _i++) {
       node = nodes[_i];
-      if (node.nodeName.substring(0, 1) === '#' || node.nodeName === 'STYLE') {
+      if (node.nodeName.substring(0, 1) === "#" || node.nodeName === 'STYLE') {
         continue;
       }
       if (node === e) {
@@ -69,13 +69,13 @@ export default class DomPredictionHelper {
 
   pathOf(elem) {
     let e, j, path, siblings, _i, _len, _ref;
-    path = '';
+    path = "";
     _ref = this.recursiveNodes(elem);
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       e = _ref[_i];
       if (e) {
         siblings = this.siblingsWithoutTextNodes(e);
-        if (e.nodeName.toLowerCase() !== 'body') {
+        if (e.nodeName.toLowerCase() !== "body") {
           j = siblings.length - 2 < 0 ? 0 : siblings.length - 2;
           while (j < siblings.length) {
             if (siblings[j] === e) {
@@ -84,7 +84,7 @@ export default class DomPredictionHelper {
             if (!siblings[j].nodeName.match(/^(script|#.*?)$/i)) {
               path +=
                 this.cssDescriptor(siblings[j]) +
-                (j + 1 === siblings.length ? '+ ' : '~ ');
+                (j + 1 === siblings.length ? "+ " : "~ ");
             }
             j++;
           }
@@ -103,7 +103,7 @@ export default class DomPredictionHelper {
       path += `#${escaped}`;
     }
     if (node.className) {
-      _ref = `${node.className}`.split(' ');
+      _ref = `${node.className}`.split(" ");
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         cssName = _ref[_i];
         escaped = this.escapeCssNames(cssName);
@@ -112,7 +112,7 @@ export default class DomPredictionHelper {
         }
       }
     }
-    if (node.nodeName.toLowerCase() !== 'body') {
+    if (node.nodeName.toLowerCase() !== "body") {
       path += `:nth-child(${this.childElemNumber(node) + 1})`;
     }
     return path;
@@ -133,10 +133,10 @@ export default class DomPredictionHelper {
     try {
       dmp = new diff_match_patch();
     } catch (e) {
-      throw 'Please include the diff_match_patch library.';
+      throw "Please include the diff_match_patch library.";
     }
-    if (typeof array === 'undefined' || array.length === 0) {
-      return '';
+    if (typeof array === "undefined" || array.length === 0) {
+      return "";
     }
     existing_tokens = {};
     encoded_css_array = this.encodeCssForDiff(array, existing_tokens);
@@ -144,7 +144,7 @@ export default class DomPredictionHelper {
     for (_i = 0, _len = encoded_css_array.length; _i < _len; _i++) {
       cssElem = encoded_css_array[_i];
       diff = dmp.diff_main(collective_common, cssElem);
-      collective_common = '';
+      collective_common = "";
       for (_j = 0, _len1 = diff.length; _j < _len1; _j++) {
         part = diff[_j];
         if (part[0] === 0) {
@@ -158,34 +158,34 @@ export default class DomPredictionHelper {
   tokenizeCss(css_string) {
     let char, skip, tokens, word, _i, _len, _ref;
     skip = false;
-    word = '';
+    word = "";
     tokens = [];
     _ref = this.cleanCss(css_string);
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       char = _ref[_i];
       if (skip) {
         skip = false;
-      } else if (char === '\\') {
+      } else if (char === "\\") {
         skip = true;
       } else if (
-        char === '.' ||
-        char === ' ' ||
-        char === '#' ||
-        char === '>' ||
-        char === ':' ||
-        char === ',' ||
-        char === '+' ||
-        char === '~'
+        char === "." ||
+        char === " " ||
+        char === "#" ||
+        char === ">" ||
+        char === ":" ||
+        char === "," ||
+        char === "+" ||
+        char === "~"
       ) {
         if (word.length > 0) {
           tokens.push(word);
         }
-        word = '';
+        word = "";
       }
       word += char;
-      if (char === ' ' || char === ',') {
+      if (char === " " || char === ",") {
         tokens.push(word);
-        word = '';
+        word = "";
       }
     }
     if (word.length > 0) {
@@ -202,11 +202,11 @@ export default class DomPredictionHelper {
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       token = _ref[_i];
       block.push(token);
-      if (token === ' ' && block.length > 0) {
+      if (token === " " && block.length > 0) {
         combined_tokens = combined_tokens.concat(block);
         block = [];
-      } else if (token === '+' || token === '~') {
-        block = [block.join('')];
+      } else if (token === "+" || token === "~") {
+        block = [block.join("")];
       }
     }
     if (block.length > 0) {
@@ -219,8 +219,8 @@ export default class DomPredictionHelper {
   decodeCss(string, existing_tokens) {
     let character, inverted, out, _i, _len, _ref;
     inverted = this.invertObject(existing_tokens);
-    out = '';
-    _ref = string.split('');
+    out = "";
+    _ref = string.split("");
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       character = _ref[_i];
       out += inverted[character];
@@ -257,25 +257,25 @@ export default class DomPredictionHelper {
       token = tokens[_i];
       first = token.substring(0, 1);
       second = token.substring(1, 2);
-      if (first === ':' && second === 'n') {
+      if (first === ":" && second === "n") {
         priorities[i] = 0;
-      } else if (first === '>') {
+      } else if (first === ">") {
         priorities[i] = 2;
-      } else if (first === '+' || first === '~') {
+      } else if (first === "+" || first === "~") {
         priorities[i] = 3;
       } else if (
-        first !== ':' &&
-        first !== '.' &&
-        first !== '#' &&
-        first !== ' ' &&
-        first !== '>' &&
-        first !== '+' &&
-        first !== '~'
+        first !== ":" &&
+        first !== "." &&
+        first !== "#" &&
+        first !== " " &&
+        first !== ">" &&
+        first !== "+" &&
+        first !== "~"
       ) {
         priorities[i] = 4;
-      } else if (first === '.') {
+      } else if (first === ".") {
         priorities[i] = 5;
-      } else if ((first = '#')) {
+      } else if ((first = "#")) {
         priorities[i] = 6;
         if (token.match(/\d{3,}/)) {
           priorities[i] = 2.5;
@@ -300,7 +300,7 @@ export default class DomPredictionHelper {
     ) {
       tmp[i] = {
         value: priorities[i],
-        original: i,
+        original: i
       };
     }
     tmp.sort(({ value: value1 }, { value: value2 }) => value1 - value2);
@@ -334,10 +334,10 @@ export default class DomPredictionHelper {
     ordering = this.orderFromPriorities(priorities);
     selector = this.cleanCss(css);
     look_back_index = -1;
-    best_so_far = '';
+    best_so_far = "";
     if (
-      this.selectorGets('all', selected, selector) &&
-      this.selectorGets('none', rejected, selector)
+      this.selectorGets("all", selected, selector) &&
+      this.selectorGets("none", rejected, selector)
     ) {
       best_so_far = selector;
     }
@@ -355,7 +355,7 @@ export default class DomPredictionHelper {
         }
         first = parts[part].substring(0, 1);
         second = parts[part].substring(1, 2);
-        if (first === ' ') {
+        if (first === " ") {
           continue;
         }
         if (this.wouldLeaveFreeFloatingNthChild(parts, part)) {
@@ -363,8 +363,8 @@ export default class DomPredictionHelper {
         }
         this._removeElements(part, parts, first, selector => {
           if (
-            _this.selectorGets('all', selected, selector) &&
-            _this.selectorGets('none', rejected, selector) &&
+            _this.selectorGets("all", selected, selector) &&
+            _this.selectorGets("none", rejected, selector) &&
             (selector.length < best_so_far.length || best_so_far.length === 0)
           ) {
             best_so_far = selector;
@@ -381,7 +381,7 @@ export default class DomPredictionHelper {
 
   _removeElements(part, parts, firstChar, callback) {
     let j, look_back_index, selector, tmp, _i, _j;
-    if (firstChar === '+' || firstChar === '~') {
+    if (firstChar === "+" || firstChar === "~") {
       look_back_index = this.positionOfSpaceBeforeIndexOrLineStart(part, parts);
     } else {
       look_back_index = part;
@@ -392,10 +392,10 @@ export default class DomPredictionHelper {
       look_back_index <= part ? _i <= part : _i >= part;
       j = look_back_index <= part ? ++_i : --_i
     ) {
-      parts[j] = '';
+      parts[j] = "";
     }
-    selector = this.cleanCss(parts.join(''));
-    if (selector === '' || !callback(selector)) {
+    selector = this.cleanCss(parts.join(""));
+    if (selector === "" || !callback(selector)) {
       for (
         j = _j = look_back_index;
         look_back_index <= part ? _j <= part : _j >= part;
@@ -410,7 +410,7 @@ export default class DomPredictionHelper {
   positionOfSpaceBeforeIndexOrLineStart(part, parts) {
     let i;
     i = part;
-    while (i >= 0 && parts[i] !== ' ') {
+    while (i >= 0 && parts[i] !== " ") {
       i--;
     }
     if (i < 0) {
@@ -426,14 +426,14 @@ export default class DomPredictionHelper {
     while (i < parts.length && parts[i].length === 0) {
       i++;
     }
-    if (i < parts.length && parts[i].substring(0, 2) === ':n') {
+    if (i < parts.length && parts[i].substring(0, 2) === ":n") {
       nth_child_is_on_right = true;
     }
     i = part - 1;
     while (i > -1 && parts[i].length === 0) {
       i--;
     }
-    if (i < 0 || parts[i] === ' ') {
+    if (i < 0 || parts[i] === " ") {
       space_is_on_left = true;
     }
     return space_is_on_left && nth_child_is_on_right;
@@ -446,20 +446,20 @@ export default class DomPredictionHelper {
     while (last_cleaned_css !== cleaned_css) {
       last_cleaned_css = cleaned_css;
       cleaned_css = cleaned_css
-        .replace(/(^|\s+)(\+|\~)/, '')
-        .replace(/(\+|\~)\s*$/, '')
-        .replace(/>/g, ' > ')
-        .replace(/\s*(>\s*)+/g, ' > ')
-        .replace(/,/g, ' , ')
-        .replace(/\s+/g, ' ')
-        .replace(/^\s+|\s+$/g, '')
-        .replace(/\s*,$/g, '')
-        .replace(/^\s*,\s*/g, '')
-        .replace(/\s*>$/g, '')
-        .replace(/^>\s*/g, '')
-        .replace(/[\+\~\>]\s*,/g, ',')
-        .replace(/[\+\~]\s*>/g, '>')
-        .replace(/\s*(,\s*)+/g, ' , ')
+        .replace(/(^|\s+)(\+|\~)/, "")
+        .replace(/(\+|\~)\s*$/, "")
+        .replace(/>/g, " > ")
+        .replace(/\s*(>\s*)+/g, " > ")
+        .replace(/,/g, " , ")
+        .replace(/\s+/g, " ")
+        .replace(/^\s+|\s+$/g, "")
+        .replace(/\s*,$/g, "")
+        .replace(/^\s*,\s*/g, "")
+        .replace(/\s*>$/g, "")
+        .replace(/^>\s*/g, "")
+        .replace(/[\+\~\>]\s*,/g, ",")
+        .replace(/[\+\~]\s*>/g, ">")
+        .replace(/\s*(,\s*)+/g, " , ")
         // if an id starts with a digit, replace it from #id format to [id="id"] format
         .replace(/#(\d([\w\-]|\\:|\\.)+)/g, '[id="$1"]');
     }
@@ -481,7 +481,7 @@ export default class DomPredictionHelper {
   predictCss(s, r) {
     let css, selected, selected_paths, simplest, union, _i, _len;
     if (s.length === 0) {
-      return '';
+      return "";
     }
     selected_paths = this.getPathsFor(s);
     css = this.cssDiff(selected_paths);
@@ -489,7 +489,7 @@ export default class DomPredictionHelper {
     if (simplest.length > 0) {
       return simplest;
     }
-    union = '';
+    union = "";
     for (_i = 0, _len = s.length; _i < _len; _i++) {
       selected = s[_i];
       union = `${this.pathOf(selected)}, ${union}`;
@@ -500,14 +500,14 @@ export default class DomPredictionHelper {
   }
 
   selectorGets(type, list, the_selector) {
-    if (list.length === 0 && type === 'all') {
+    if (list.length === 0 && type === "all") {
       return false;
     }
-    if (list.length === 0 && type === 'none') {
+    if (list.length === 0 && type === "none") {
       return true;
     }
     try {
-      if (type === 'all') {
+      if (type === "all") {
         return [...list].every(node => node.matches(the_selector));
       } else {
         return [...list].every(node => !node.matches(the_selector));
@@ -533,17 +533,17 @@ export default class DomPredictionHelper {
   cssToXPath(css_string) {
     let css_block, out, token, tokens, _i, _len;
     tokens = this.tokenizeCss(css_string);
-    if (tokens[0] && tokens[0] === ' ') {
+    if (tokens[0] && tokens[0] === " ") {
       tokens.splice(0, 1);
     }
-    if (tokens[tokens.length - 1] && tokens[tokens.length - 1] === ' ') {
+    if (tokens[tokens.length - 1] && tokens[tokens.length - 1] === " ") {
       tokens.splice(tokens.length - 1, 1);
     }
     css_block = [];
-    out = '';
+    out = "";
     for (_i = 0, _len = tokens.length; _i < _len; _i++) {
       token = tokens[_i];
-      if (token === ' ') {
+      if (token === " ") {
         out += this.cssToXPathBlockHelper(css_block);
         css_block = [];
       } else {
@@ -556,15 +556,15 @@ export default class DomPredictionHelper {
   cssToXPathBlockHelper(css_block) {
     let current, expressions, first, i, out, re, rest, _i, _j, _len, _ref;
     if (css_block.length === 0) {
-      return '//';
+      return "//";
     }
-    out = '//';
+    out = "//";
     first = css_block[0].substring(0, 1);
-    if (first === ',') {
-      return ' | ';
+    if (first === ",") {
+      return " | ";
     }
-    if (first === ':' || first === '#' || first === '.') {
-      out += '*';
+    if (first === ":" || first === "#" || first === ".") {
+      out += "*";
     }
     expressions = [];
     re = null;
@@ -572,25 +572,25 @@ export default class DomPredictionHelper {
       current = css_block[_i];
       first = current.substring(0, 1);
       rest = current.substring(1);
-      if (first === ':') {
+      if (first === ":") {
         if ((re = rest.match(/^nth-child\((\d+)\)$/))) {
           expressions.push(
             `(((count(preceding-sibling::*) + 1) = ${re[1]}) and parent::*)`
           );
         }
-      } else if (first === '.') {
+      } else if (first === ".") {
         expressions.push(
           `contains(concat( " ", @class, " " ), concat( " ", "${rest}", " " ))`
         );
-      } else if (first === '#') {
+      } else if (first === "#") {
         expressions.push(`(@id = "${rest}")`);
-      } else if (first === ',') {
+      } else if (first === ",") {
       } else {
         out += current;
       }
     }
     if (expressions.length > 0) {
-      out += '[';
+      out += "[";
     }
     for (
       i = _j = 0, _ref = expressions.length;
@@ -599,11 +599,11 @@ export default class DomPredictionHelper {
     ) {
       out += expressions[i];
       if (i < expressions.length - 1) {
-        out += ' and ';
+        out += " and ";
       }
     }
     if (expressions.length > 0) {
-      out += ']';
+      out += "]";
     }
     return out;
   }

--- a/app/index.js
+++ b/app/index.js
@@ -459,7 +459,8 @@ export default class DomPredictionHelper {
         .replace(/^>\s*/g, "")
         .replace(/[\+\~\>]\s*,/g, ",")
         .replace(/[\+\~]\s*>/g, ">")
-        .replace(/\s*(,\s*)+/g, " , ");
+        .replace(/\s*(,\s*)+/g, " , ")
+        .replace(/#(\d[\w\-]+)/g, '[id="$1"]');
     }
     return cleaned_css;
   }
@@ -506,9 +507,9 @@ export default class DomPredictionHelper {
     }
     try {
       if (type === "all") {
-        return list.not(the_selector).length === 0;
+        return [...list].every(node => node.matches(the_selector));
       } else {
-        return !list.is(the_selector);
+        return [...list].every(node => !node.matches(the_selector));
       }
     } catch (e) {
       if (window.console) {

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-import { diff_match_patch } from "diff_match_patch";
+import { diff_match_patch } from 'diff_match_patch';
 
 export default class DomPredictionHelper {
   recursiveNodes(e) {
@@ -8,7 +8,7 @@ export default class DomPredictionHelper {
     } else {
       n = new Array();
     }
-    
+
     if (e.host && e.host.shadowRoot) return n;
     n.push(e);
     return n;
@@ -18,24 +18,24 @@ export default class DomPredictionHelper {
     if (name) {
       try {
         return name
-          .replace(/\bselectorgadget_\w+\b/g, "")
-          .replace(/\\/g, "\\\\")
+          .replace(/\bselectorgadget_\w+\b/g, '')
+          .replace(/\\/g, '\\\\')
           .replace(
             /[\#\;\&\,\.\+\*\~\'\:\"\!\^\$\[\]\(\)\=\>\|\/]/g,
             e => `\\${e}`
           )
-          .replace(/\s+/, "");
+          .replace(/\s+/, '');
       } catch (e) {
         if (window.console) {
-          console.log("---");
-          console.log("exception in escapeCssNames");
+          console.log('---');
+          console.log('exception in escapeCssNames');
           console.log(name);
-          console.log("---");
+          console.log('---');
         }
-        return "";
+        return '';
       }
     } else {
-      return "";
+      return '';
     }
   }
 
@@ -56,7 +56,7 @@ export default class DomPredictionHelper {
     filtered_nodes = [];
     for (_i = 0, _len = nodes.length; _i < _len; _i++) {
       node = nodes[_i];
-      if (node.nodeName.substring(0, 1) === "#" || node.nodeName === 'STYLE') {
+      if (node.nodeName.substring(0, 1) === '#' || node.nodeName === 'STYLE') {
         continue;
       }
       if (node === e) {
@@ -69,13 +69,13 @@ export default class DomPredictionHelper {
 
   pathOf(elem) {
     let e, j, path, siblings, _i, _len, _ref;
-    path = "";
+    path = '';
     _ref = this.recursiveNodes(elem);
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       e = _ref[_i];
       if (e) {
         siblings = this.siblingsWithoutTextNodes(e);
-        if (e.nodeName.toLowerCase() !== "body") {
+        if (e.nodeName.toLowerCase() !== 'body') {
           j = siblings.length - 2 < 0 ? 0 : siblings.length - 2;
           while (j < siblings.length) {
             if (siblings[j] === e) {
@@ -84,7 +84,7 @@ export default class DomPredictionHelper {
             if (!siblings[j].nodeName.match(/^(script|#.*?)$/i)) {
               path +=
                 this.cssDescriptor(siblings[j]) +
-                (j + 1 === siblings.length ? "+ " : "~ ");
+                (j + 1 === siblings.length ? '+ ' : '~ ');
             }
             j++;
           }
@@ -103,7 +103,7 @@ export default class DomPredictionHelper {
       path += `#${escaped}`;
     }
     if (node.className) {
-      _ref = `${node.className}`.split(" ");
+      _ref = `${node.className}`.split(' ');
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         cssName = _ref[_i];
         escaped = this.escapeCssNames(cssName);
@@ -112,7 +112,7 @@ export default class DomPredictionHelper {
         }
       }
     }
-    if (node.nodeName.toLowerCase() !== "body") {
+    if (node.nodeName.toLowerCase() !== 'body') {
       path += `:nth-child(${this.childElemNumber(node) + 1})`;
     }
     return path;
@@ -133,10 +133,10 @@ export default class DomPredictionHelper {
     try {
       dmp = new diff_match_patch();
     } catch (e) {
-      throw "Please include the diff_match_patch library.";
+      throw 'Please include the diff_match_patch library.';
     }
-    if (typeof array === "undefined" || array.length === 0) {
-      return "";
+    if (typeof array === 'undefined' || array.length === 0) {
+      return '';
     }
     existing_tokens = {};
     encoded_css_array = this.encodeCssForDiff(array, existing_tokens);
@@ -144,7 +144,7 @@ export default class DomPredictionHelper {
     for (_i = 0, _len = encoded_css_array.length; _i < _len; _i++) {
       cssElem = encoded_css_array[_i];
       diff = dmp.diff_main(collective_common, cssElem);
-      collective_common = "";
+      collective_common = '';
       for (_j = 0, _len1 = diff.length; _j < _len1; _j++) {
         part = diff[_j];
         if (part[0] === 0) {
@@ -158,34 +158,34 @@ export default class DomPredictionHelper {
   tokenizeCss(css_string) {
     let char, skip, tokens, word, _i, _len, _ref;
     skip = false;
-    word = "";
+    word = '';
     tokens = [];
     _ref = this.cleanCss(css_string);
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       char = _ref[_i];
       if (skip) {
         skip = false;
-      } else if (char === "\\") {
+      } else if (char === '\\') {
         skip = true;
       } else if (
-        char === "." ||
-        char === " " ||
-        char === "#" ||
-        char === ">" ||
-        char === ":" ||
-        char === "," ||
-        char === "+" ||
-        char === "~"
+        char === '.' ||
+        char === ' ' ||
+        char === '#' ||
+        char === '>' ||
+        char === ':' ||
+        char === ',' ||
+        char === '+' ||
+        char === '~'
       ) {
         if (word.length > 0) {
           tokens.push(word);
         }
-        word = "";
+        word = '';
       }
       word += char;
-      if (char === " " || char === ",") {
+      if (char === ' ' || char === ',') {
         tokens.push(word);
-        word = "";
+        word = '';
       }
     }
     if (word.length > 0) {
@@ -202,11 +202,11 @@ export default class DomPredictionHelper {
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       token = _ref[_i];
       block.push(token);
-      if (token === " " && block.length > 0) {
+      if (token === ' ' && block.length > 0) {
         combined_tokens = combined_tokens.concat(block);
         block = [];
-      } else if (token === "+" || token === "~") {
-        block = [block.join("")];
+      } else if (token === '+' || token === '~') {
+        block = [block.join('')];
       }
     }
     if (block.length > 0) {
@@ -219,8 +219,8 @@ export default class DomPredictionHelper {
   decodeCss(string, existing_tokens) {
     let character, inverted, out, _i, _len, _ref;
     inverted = this.invertObject(existing_tokens);
-    out = "";
-    _ref = string.split("");
+    out = '';
+    _ref = string.split('');
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       character = _ref[_i];
       out += inverted[character];
@@ -257,25 +257,25 @@ export default class DomPredictionHelper {
       token = tokens[_i];
       first = token.substring(0, 1);
       second = token.substring(1, 2);
-      if (first === ":" && second === "n") {
+      if (first === ':' && second === 'n') {
         priorities[i] = 0;
-      } else if (first === ">") {
+      } else if (first === '>') {
         priorities[i] = 2;
-      } else if (first === "+" || first === "~") {
+      } else if (first === '+' || first === '~') {
         priorities[i] = 3;
       } else if (
-        first !== ":" &&
-        first !== "." &&
-        first !== "#" &&
-        first !== " " &&
-        first !== ">" &&
-        first !== "+" &&
-        first !== "~"
+        first !== ':' &&
+        first !== '.' &&
+        first !== '#' &&
+        first !== ' ' &&
+        first !== '>' &&
+        first !== '+' &&
+        first !== '~'
       ) {
         priorities[i] = 4;
-      } else if (first === ".") {
+      } else if (first === '.') {
         priorities[i] = 5;
-      } else if ((first = "#")) {
+      } else if ((first = '#')) {
         priorities[i] = 6;
         if (token.match(/\d{3,}/)) {
           priorities[i] = 2.5;
@@ -300,7 +300,7 @@ export default class DomPredictionHelper {
     ) {
       tmp[i] = {
         value: priorities[i],
-        original: i
+        original: i,
       };
     }
     tmp.sort(({ value: value1 }, { value: value2 }) => value1 - value2);
@@ -334,10 +334,10 @@ export default class DomPredictionHelper {
     ordering = this.orderFromPriorities(priorities);
     selector = this.cleanCss(css);
     look_back_index = -1;
-    best_so_far = "";
+    best_so_far = '';
     if (
-      this.selectorGets("all", selected, selector) &&
-      this.selectorGets("none", rejected, selector)
+      this.selectorGets('all', selected, selector) &&
+      this.selectorGets('none', rejected, selector)
     ) {
       best_so_far = selector;
     }
@@ -355,7 +355,7 @@ export default class DomPredictionHelper {
         }
         first = parts[part].substring(0, 1);
         second = parts[part].substring(1, 2);
-        if (first === " ") {
+        if (first === ' ') {
           continue;
         }
         if (this.wouldLeaveFreeFloatingNthChild(parts, part)) {
@@ -363,8 +363,8 @@ export default class DomPredictionHelper {
         }
         this._removeElements(part, parts, first, selector => {
           if (
-            _this.selectorGets("all", selected, selector) &&
-            _this.selectorGets("none", rejected, selector) &&
+            _this.selectorGets('all', selected, selector) &&
+            _this.selectorGets('none', rejected, selector) &&
             (selector.length < best_so_far.length || best_so_far.length === 0)
           ) {
             best_so_far = selector;
@@ -381,7 +381,7 @@ export default class DomPredictionHelper {
 
   _removeElements(part, parts, firstChar, callback) {
     let j, look_back_index, selector, tmp, _i, _j;
-    if (firstChar === "+" || firstChar === "~") {
+    if (firstChar === '+' || firstChar === '~') {
       look_back_index = this.positionOfSpaceBeforeIndexOrLineStart(part, parts);
     } else {
       look_back_index = part;
@@ -392,10 +392,10 @@ export default class DomPredictionHelper {
       look_back_index <= part ? _i <= part : _i >= part;
       j = look_back_index <= part ? ++_i : --_i
     ) {
-      parts[j] = "";
+      parts[j] = '';
     }
-    selector = this.cleanCss(parts.join(""));
-    if (selector === "" || !callback(selector)) {
+    selector = this.cleanCss(parts.join(''));
+    if (selector === '' || !callback(selector)) {
       for (
         j = _j = look_back_index;
         look_back_index <= part ? _j <= part : _j >= part;
@@ -410,7 +410,7 @@ export default class DomPredictionHelper {
   positionOfSpaceBeforeIndexOrLineStart(part, parts) {
     let i;
     i = part;
-    while (i >= 0 && parts[i] !== " ") {
+    while (i >= 0 && parts[i] !== ' ') {
       i--;
     }
     if (i < 0) {
@@ -426,14 +426,14 @@ export default class DomPredictionHelper {
     while (i < parts.length && parts[i].length === 0) {
       i++;
     }
-    if (i < parts.length && parts[i].substring(0, 2) === ":n") {
+    if (i < parts.length && parts[i].substring(0, 2) === ':n') {
       nth_child_is_on_right = true;
     }
     i = part - 1;
     while (i > -1 && parts[i].length === 0) {
       i--;
     }
-    if (i < 0 || parts[i] === " ") {
+    if (i < 0 || parts[i] === ' ') {
       space_is_on_left = true;
     }
     return space_is_on_left && nth_child_is_on_right;
@@ -446,20 +446,21 @@ export default class DomPredictionHelper {
     while (last_cleaned_css !== cleaned_css) {
       last_cleaned_css = cleaned_css;
       cleaned_css = cleaned_css
-        .replace(/(^|\s+)(\+|\~)/, "")
-        .replace(/(\+|\~)\s*$/, "")
-        .replace(/>/g, " > ")
-        .replace(/\s*(>\s*)+/g, " > ")
-        .replace(/,/g, " , ")
-        .replace(/\s+/g, " ")
-        .replace(/^\s+|\s+$/g, "")
-        .replace(/\s*,$/g, "")
-        .replace(/^\s*,\s*/g, "")
-        .replace(/\s*>$/g, "")
-        .replace(/^>\s*/g, "")
-        .replace(/[\+\~\>]\s*,/g, ",")
-        .replace(/[\+\~]\s*>/g, ">")
-        .replace(/\s*(,\s*)+/g, " , ")
+        .replace(/(^|\s+)(\+|\~)/, '')
+        .replace(/(\+|\~)\s*$/, '')
+        .replace(/>/g, ' > ')
+        .replace(/\s*(>\s*)+/g, ' > ')
+        .replace(/,/g, ' , ')
+        .replace(/\s+/g, ' ')
+        .replace(/^\s+|\s+$/g, '')
+        .replace(/\s*,$/g, '')
+        .replace(/^\s*,\s*/g, '')
+        .replace(/\s*>$/g, '')
+        .replace(/^>\s*/g, '')
+        .replace(/[\+\~\>]\s*,/g, ',')
+        .replace(/[\+\~]\s*>/g, '>')
+        .replace(/\s*(,\s*)+/g, ' , ')
+        // if an id starts with a digit, replace it from #id format to [id="id"] format
         .replace(/#(\d([\w\-]|\\:|\\.)+)/g, '[id="$1"]');
     }
     return cleaned_css;
@@ -480,7 +481,7 @@ export default class DomPredictionHelper {
   predictCss(s, r) {
     let css, selected, selected_paths, simplest, union, _i, _len;
     if (s.length === 0) {
-      return "";
+      return '';
     }
     selected_paths = this.getPathsFor(s);
     css = this.cssDiff(selected_paths);
@@ -488,7 +489,7 @@ export default class DomPredictionHelper {
     if (simplest.length > 0) {
       return simplest;
     }
-    union = "";
+    union = '';
     for (_i = 0, _len = s.length; _i < _len; _i++) {
       selected = s[_i];
       union = `${this.pathOf(selected)}, ${union}`;
@@ -499,14 +500,14 @@ export default class DomPredictionHelper {
   }
 
   selectorGets(type, list, the_selector) {
-    if (list.length === 0 && type === "all") {
+    if (list.length === 0 && type === 'all') {
       return false;
     }
-    if (list.length === 0 && type === "none") {
+    if (list.length === 0 && type === 'none') {
       return true;
     }
     try {
-      if (type === "all") {
+      if (type === 'all') {
         return [...list].every(node => node.matches(the_selector));
       } else {
         return [...list].every(node => !node.matches(the_selector));
@@ -532,17 +533,17 @@ export default class DomPredictionHelper {
   cssToXPath(css_string) {
     let css_block, out, token, tokens, _i, _len;
     tokens = this.tokenizeCss(css_string);
-    if (tokens[0] && tokens[0] === " ") {
+    if (tokens[0] && tokens[0] === ' ') {
       tokens.splice(0, 1);
     }
-    if (tokens[tokens.length - 1] && tokens[tokens.length - 1] === " ") {
+    if (tokens[tokens.length - 1] && tokens[tokens.length - 1] === ' ') {
       tokens.splice(tokens.length - 1, 1);
     }
     css_block = [];
-    out = "";
+    out = '';
     for (_i = 0, _len = tokens.length; _i < _len; _i++) {
       token = tokens[_i];
-      if (token === " ") {
+      if (token === ' ') {
         out += this.cssToXPathBlockHelper(css_block);
         css_block = [];
       } else {
@@ -555,15 +556,15 @@ export default class DomPredictionHelper {
   cssToXPathBlockHelper(css_block) {
     let current, expressions, first, i, out, re, rest, _i, _j, _len, _ref;
     if (css_block.length === 0) {
-      return "//";
+      return '//';
     }
-    out = "//";
+    out = '//';
     first = css_block[0].substring(0, 1);
-    if (first === ",") {
-      return " | ";
+    if (first === ',') {
+      return ' | ';
     }
-    if (first === ":" || first === "#" || first === ".") {
-      out += "*";
+    if (first === ':' || first === '#' || first === '.') {
+      out += '*';
     }
     expressions = [];
     re = null;
@@ -571,25 +572,25 @@ export default class DomPredictionHelper {
       current = css_block[_i];
       first = current.substring(0, 1);
       rest = current.substring(1);
-      if (first === ":") {
+      if (first === ':') {
         if ((re = rest.match(/^nth-child\((\d+)\)$/))) {
           expressions.push(
             `(((count(preceding-sibling::*) + 1) = ${re[1]}) and parent::*)`
           );
         }
-      } else if (first === ".") {
+      } else if (first === '.') {
         expressions.push(
           `contains(concat( " ", @class, " " ), concat( " ", "${rest}", " " ))`
         );
-      } else if (first === "#") {
+      } else if (first === '#') {
         expressions.push(`(@id = "${rest}")`);
-      } else if (first === ",") {
+      } else if (first === ',') {
       } else {
         out += current;
       }
     }
     if (expressions.length > 0) {
-      out += "[";
+      out += '[';
     }
     for (
       i = _j = 0, _ref = expressions.length;
@@ -598,11 +599,11 @@ export default class DomPredictionHelper {
     ) {
       out += expressions[i];
       if (i < expressions.length - 1) {
-        out += " and ";
+        out += ' and ';
       }
     }
     if (expressions.length > 0) {
-      out += "]";
+      out += ']';
     }
     return out;
   }

--- a/example/groups/first-comments.js
+++ b/example/groups/first-comments.js
@@ -1,4 +1,4 @@
-export default function example(select, helper, jQuery) {
+export default function example(select, helper) {
   const firstTitleElem = document.querySelector(".subtext a+ a");
   const firstTitleSelector = select(firstTitleElem);
 
@@ -9,8 +9,8 @@ export default function example(select, helper, jQuery) {
   const hideElemSelector = select(hideElem);
 
   const commonSelector = helper.predictCss(
-    jQuery(firstTitleSelector),
-    jQuery([topBarSelector, hideElemSelector].join(","))
+    document.querySelectorAll(firstTitleSelector),
+    document.querySelectorAll([topBarSelector, hideElemSelector].join(","))
   );
   const results = document.querySelectorAll(commonSelector);
 
@@ -30,7 +30,7 @@ export default function example(select, helper, jQuery) {
   );
   console.log(
     `We will get a common selector ` +
-      `%c${helper.predictCss(jQuery(firstTitleSelector), [])}`,
+      `%c${helper.predictCss(document.querySelectorAll(firstTitleSelector), [])}`,
     "color: green; font-weight:bold;"
   );
   console.log(

--- a/example/groups/first-comments.js
+++ b/example/groups/first-comments.js
@@ -25,7 +25,7 @@ export default function example(select, helper) {
   );
   console.log(
     `If we pass it like ` +
-      `%chelper.predictCss(jQuery("${firstTitleSelector}"), [])`,
+      `%chelper.predictCss(document.querySelectorAll("${firstTitleSelector}"), [])`,
     "color: brown; font-weight:bold;"
   );
   console.log(
@@ -42,7 +42,7 @@ export default function example(select, helper) {
   );
   console.log(
     `Like this ` +
-      `%chelper.predictCss(jQuery("${firstTitleSelector}"), jQuery(\`${hideElemSelector}, ${topBarSelector}\`))`,
+      `%chelper.predictCss(document.querySelectorAll("${firstTitleSelector}"), document.querySelectorAll(\`${hideElemSelector}, ${topBarSelector}\`))`,
     "color: brown; font-weight:bold;"
   );
   console.log(

--- a/example/groups/first-title.js
+++ b/example/groups/first-title.js
@@ -14,7 +14,7 @@ export default function example(select, helper) {
   );
   console.log(
     `If we pass it like ` +
-      `%chelper.predictCss(jQuery("${firstTitleSelector}"), [])`,
+      `%chelper.predictCss(document.querySelectorAll("${firstTitleSelector}"), [])`,
     "color: brown; font-weight:bold;"
   );
   console.log(

--- a/example/groups/first-title.js
+++ b/example/groups/first-title.js
@@ -1,4 +1,4 @@
-export default function example(select, helper, jQuery) {
+export default function example(select, helper) {
   const firstTitleElem = document.querySelector(".storylink");
   const firstTitleSelector = select(firstTitleElem);
   // will produce unique selector
@@ -19,7 +19,7 @@ export default function example(select, helper, jQuery) {
   );
   console.log(
     `We will get a common selector ` +
-      `%c${helper.predictCss(jQuery(firstTitleSelector), [])}`,
+      `%c${helper.predictCss(document.querySelectorAll(firstTitleSelector), [])}`,
     "color: green; font-weight:bold;"
   );
   

--- a/example/script.js
+++ b/example/script.js
@@ -1,5 +1,4 @@
 import "./source";
-import jQuery from "jquery";
 import DomPredictionHelper from "../app";
 
 import titles from './groups/first-title';
@@ -7,8 +6,8 @@ import comments from './groups/first-comments';
 import { select } from "optimal-select";
 
 // expose basic required functions
-window.jQuery = jQuery;
-window.$ = jQuery;
+// window.jQuery = jQuery;
+// window.$ = jQuery;
 window.DomPredictionHelper = DomPredictionHelper;
 
 // expose an instance for live experiments
@@ -22,5 +21,5 @@ console.info(
 // optimal-select is optional
 // this is for demonstration purpose only.
 window.select = select;
-titles(select, helper, jQuery);
-comments(select, helper, jQuery);
+titles(select, helper);
+comments(select, helper);

--- a/example/source/index.html
+++ b/example/source/index.html
@@ -209,7 +209,7 @@ pre { max-width: 900px; }
                           </span></td>
               </tr></tbody></table></td></tr>
 <tr id="pagespace" title="" style="height:10px"></tr><tr><td><table border="0" cellpadding="0" cellspacing="0" class="itemlist">
-              <tbody><tr class="athing" id="21050149">
+              <tbody><tr class="athing" id="210:50149">
       <td align="right" valign="top" class="title"><span class="rank">1.</span></td>      <td valign="top" class="votelinks"><center><a id="up_21050149" href="vote?id=21050149&how=up&goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><a href="https://www.apple.com/newsroom/2019/09/apples-new-mac-pro-to-be-made-in-texas/" class="storylink">Apple’s New Mac Pro to Be Made in Texas</a><span class="sitebit comhead"> (<a href="from?site=apple.com"><span class="sitestr">apple.com</span></a>)</span></td></tr><tr><td colspan="2"></td><td class="subtext">
         <span class="score" id="score_21050149">149 points</span> by <a href="user?id=infodocket" class="hnuser">infodocket</a> <span class="age"><a href="item?id=21050149">43 minutes ago</a></span> <span id="unv_21050149"></span> | <a href="hide?id=21050149&goto=news">hide</a> | <a href="item?id=21050149">69 comments</a>              </td></tr>
       <tr class="spacer" style="height:5px"></tr>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "diff_match_patch": "^0.1.1",
-    "jquery": "^3.4.1",
     "optimal-select": "^4.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,11 +4011,6 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-jquery@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
 js-beautify@^1.8.9:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.10.2.tgz#88c9099cd6559402b124cfab18754936f8a7b178"


### PR DESCRIPTION
There were two jQuery specific methods being used: `.not` and `.is` to check if all or none of the nodes matches a specific selector.

Replaced them with `[...list].every(node => node.matches(selector))`

That causes a problem: HTML5 allows id names to start with a digit and jQuery can handle this. But not `.matches`. So in the `cleanCss` method, added a regex to replace it from `#id` format to `[id="id"]` format  if that id starts with a digit.